### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.0</version>
+		<version>2.7.5</version>
 	</extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,9 +5,4 @@
 		<artifactId>tycho-build</artifactId>
 		<version>2.7.0</version>
 	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
-	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.9.0</version>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.envdyn</groupId>
 	<artifactId>parent</artifactId>	
@@ -14,7 +14,7 @@
 	<packaging>pom</packaging>
 	
 	<properties>
-		<org.palladiosimulator.maven.tychotprefresh.tplocation.2>${project.basedir}/releng/org.palladiosimulator.envdyn.targetplatform/tp.target</org.palladiosimulator.maven.tychotprefresh.tplocation.2>
+		<targetPlatform.relativePath>releng/org.palladiosimulator.envdyn.targetplatform/tp.target</targetPlatform.relativePath>
 	</properties>
 	
 	<modules>

--- a/releng/org.palladiosimulator.envdyn.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.envdyn.targetplatform/tp.target
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="org.palladiosimulator.envdyn Target Platform" sequenceNumber="1">
+<?pde version="3.8"?><target name="org.palladiosimulator.envdyn Target Platform" sequenceNumber="2">
 	<locations>
+		<location type="Target" uri="mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03"/>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository"/>
 			<unit id="org.assertj" version="3.20.2.v20210706-1104"/>
@@ -13,47 +14,31 @@
 			<unit id="org.eclipse.m2m.qvt.oml" version="3.10.7.v20220605-1149"/>
 			<unit id="org.eclipse.m2m.qvt.oml.source" version="3.10.7.v20220605-1149"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.mdsd.tools/metamodel-modeling-foundations/nightly/"/>
 			<unit id="tools.mdsd.modelingfoundations.identifier.feature.feature.group" version="0.0.0"/>
 			<unit id="tools.mdsd.modelingfoundations.identifier.ui.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.mdsd.tools/metamodel-modeling-probabilitydistributions/nightly/"/>
 			<unit id="tools.mdsd.probdist.model.feature.feature.group" version="0.0.0"/>
 			<unit id="tools.mdsd.probdist.api.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/releases/latest/"/>
-			<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="tbd"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/nightly/"/>
-			<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="tbd"/>
+			<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/latest/"/>
-			<unit id="org.modelversioning.emfprofile.feature.feature.group" version="tbd"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/nightly/"/>
-			<unit id="org.modelversioning.emfprofile.feature.feature.group" version="tbd"/>
+			<unit id="org.modelversioning.emfprofile.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/latest/"/>
-			<unit id="dorg.palladiosimulator.commons.feature.feature.group" version="tbd"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
-			<unit id="org.palladiosimulator.commons.feature.feature.group" version="tbd"/>
+			<unit id="org.palladiosimulator.commons.feature.feature.group" version="0.0.0"/>
 		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/latest/"/>
-			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="tbd"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
-			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="tbd"/>
+			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="0.0.0"/>
 		</location>
 	</locations>
 </target>

--- a/releng/org.palladiosimulator.envdyn.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.envdyn.targetplatform/tp.target
@@ -1,66 +1,59 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?><target name="org.palladiosimulator.envdyn Target Platform" sequenceNumber="1">
-<locations>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository"/>
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230302014618/repository"/>
 			<unit id="org.assertj" version="3.20.2.v20210706-1104"/>
 			<unit id="org.assertj.source" version="3.20.2.v20210706-1104"/>
-	</location>
-
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/releases/2023-03/202303151000/"/>
-        <unit id="org.eclipse.core.runtime.feature.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.ocl.examples.feature.group" version="0.0.0"/>
-		<unit id="org.eclipse.m2m.qvt.oml" version="3.10.7.v20220605-1149"/>
-		<unit id="org.eclipse.m2m.qvt.oml.source" version="3.10.7.v20220605-1149"/>
-    </location>
-	
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.mdsd.tools/metamodel-modeling-foundations/nightly/"/>
-        <unit id="tools.mdsd.modelingfoundations.identifier.feature.feature.group" version="0.0.0"/>
-		<unit id="tools.mdsd.modelingfoundations.identifier.ui.feature.feature.group" version="0.0.0"/>
-    </location>
-	
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-        <repository location="https://updatesite.mdsd.tools/metamodel-modeling-probabilitydistributions/nightly/"/>
-        <unit id="tools.mdsd.probdist.model.feature.feature.group" version="0.0.0"/>
-		<unit id="tools.mdsd.probdist.api.feature.feature.group" version="0.0.0"/>
-    </location>
-	
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/releases/latest/"/>
-		<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="tbd"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/nightly/"/>
-		<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="tbd"/>
-	</location>
-	
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/latest/"/>
-		<unit id="org.modelversioning.emfprofile.feature.feature.group" version="tbd"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/nightly/"/>
-		<unit id="org.modelversioning.emfprofile.feature.feature.group" version="tbd"/>
-	</location>
-	
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/latest/"/>
-		<unit id="dorg.palladiosimulator.commons.feature.feature.group" version="tbd"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
-		<unit id="org.palladiosimulator.commons.feature.feature.group" version="tbd"/>
-	</location>
-
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/latest/"/>
-		<unit id="org.palladiosimulator.pcm.feature.feature.group" version="tbd"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
-		<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
-		<unit id="org.palladiosimulator.pcm.feature.feature.group" version="tbd"/>
-	</location>
-</locations>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2023-03/202303151000/"/>
+			<unit id="org.eclipse.core.runtime.feature.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.ocl.examples.feature.group" version="0.0.0"/>
+			<unit id="org.eclipse.m2m.qvt.oml" version="3.10.7.v20220605-1149"/>
+			<unit id="org.eclipse.m2m.qvt.oml.source" version="3.10.7.v20220605-1149"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+			<repository location="https://updatesite.mdsd.tools/metamodel-modeling-foundations/nightly/"/>
+			<unit id="tools.mdsd.modelingfoundations.identifier.feature.feature.group" version="0.0.0"/>
+			<unit id="tools.mdsd.modelingfoundations.identifier.ui.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+			<repository location="https://updatesite.mdsd.tools/metamodel-modeling-probabilitydistributions/nightly/"/>
+			<unit id="tools.mdsd.probdist.model.feature.feature.group" version="0.0.0"/>
+			<unit id="tools.mdsd.probdist.api.feature.feature.group" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/releases/latest/"/>
+			<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="tbd"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-supporting-mdsdprofiles/nightly/"/>
+			<unit id="org.palladiosimulator.mdsdprofiles.feature.feature.group" version="tbd"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/releases/latest/"/>
+			<unit id="org.modelversioning.emfprofile.feature.feature.group" version="tbd"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-thirdparty-emfprofiles/nightly/"/>
+			<unit id="org.modelversioning.emfprofile.feature.feature.group" version="tbd"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/releases/latest/"/>
+			<unit id="dorg.palladiosimulator.commons.feature.feature.group" version="tbd"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-commons/nightly/"/>
+			<unit id="org.palladiosimulator.commons.feature.feature.group" version="tbd"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="release" refresh="true">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/latest/"/>
+			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="tbd"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit" filter="nightly" refresh="true">
+			<repository location="https://updatesite.palladio-simulator.com/palladio-core-pcm/nightly/"/>
+			<unit id="org.palladiosimulator.pcm.feature.feature.group" version="tbd"/>
+		</location>
+	</locations>
 </target>


### PR DESCRIPTION
### Overview
- Migrate from parent POM version `0.9.0` to the new parent POM version `0.10.0`
- Locally verified build success

### Changes
- In `pom.xml`:
  - Parent POM updated from `0.9.0` to `0.10.0`  
  - Renamed property `org.palladiosimulator.maven.tychotprefresh.tplocation.2` to `targetPlatform.relativePath` and trimmed its path value to start at `releng`  
- In `.mvn/extensions.xml`:
  - Removed `<extension>` block for `org.palladiosimulator:tycho-tp-refresh-maven-plugin`  
- In the target platform `tp.target`:
  - Inserted new `<location>` with URI `mvn:org.palladiosimulator:palladio-target-platforms:0.1.0:target:palladio-2023-03`, since the Palladio target platform is now decoupled from the parent POM  
  - Unified all `includeSource` attributes by setting them to `false`, as the value must be the same across all locations to prevent resolution failure  
  - Removed specifics of the `tycho-tp-refresh-maven-plugin` to be standard-compliant:  
    - Removed any `<location filter="release">` entries  
    - Removed `filter="nightly"` attributes  
    - Removed all `refresh="true"` attributes and, where present, set each `<unit>`’s `version` attribute to `0.0.0`  
  - Added indentation to improve readability